### PR TITLE
Add default param handling, Remove Spring dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class AnnotatedTestClass {
 }
 ```
 
-If you would like to check the class to be annotated only with `@MyAnnotation` use the following
+If you would like to check the class to be annotated only with `@MyAnnotation` and only have the configured params use the following
 
 ```
 import static de.tolina.common.validation.AnnotationDefinition.*;
@@ -41,7 +41,19 @@ import static de.tolina.common.validation.AnnotationDefinition.*;
 
 validate().exactly() //
 	.annotation(type(MyAnnotation.class) //
-		.param("foo", "default") //
+		.param("foo", "default")) //
+	.forClass(AnnotatedTestClass.class);
+```
+
+If you would like to check the class to be annotated only with `@MyAnnotation` but also want to consider default values for not configured params use the following
+
+```
+import static de.tolina.common.validation.AnnotationDefinition.*;
+
+...
+
+validate().only() //
+	.annotation(type(MyAnnotation.class)) //
 	.forClass(AnnotatedTestClass.class);
 ```
 
@@ -50,7 +62,7 @@ If you would like to check the field to be annotated with `@MyAnnotation`, where
 ```
 validate() //
 	.annotation(type(MyAnnotation.class) //
-		.param("foo", "bar") //
+		.param("foo", "bar")) //
 	.forField(AnnotatedTestClass.class.getDeclaredField("fieldWithAnnotations"));
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>de.tolina.common.validation</groupId>
 	<artifactId>annotation-validator</artifactId>
-	<version>1.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Annotation Validator</name>
@@ -48,6 +48,10 @@
 		<developer>
 			<name>Ron Peters</name>
 			<email>ron.peters@arxes-tolina.de</email>
+		</developer>
+		<developer>
+			<name>Matthias Hartmann</name>
+			<email>matthias.hartmann@signavio.com</email>
 		</developer>
 		<developer>
 			<name>Frank Jakop</name>
@@ -91,12 +95,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>4.3.6.RELEASE</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.4</version>
@@ -121,6 +119,13 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.3.6.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/de/tolina/common/validation/AnnotationValidation.java
+++ b/src/main/java/de/tolina/common/validation/AnnotationValidation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/de/tolina/common/validation/AnnotationValidation.java
+++ b/src/main/java/de/tolina/common/validation/AnnotationValidation.java
@@ -79,7 +79,7 @@ public class AnnotationValidation {
 	
 	
 	/**
-	 * Validates that no other Annotations are defined
+	 * Validates that no other Annotations are defined and only the defined params are present.
 	 *
 	 * @return the AnnotationValidator
 	 */
@@ -91,7 +91,7 @@ public class AnnotationValidation {
 	
 	
 	/**
-	 * Validates that no other Annotations are defined
+	 * Validates that no other Annotations are defined considering default values for undefined params.
 	 *
 	 * @return the AnnotationValidator
 	 */

--- a/src/main/java/de/tolina/common/validation/ValidationMode.java
+++ b/src/main/java/de/tolina/common/validation/ValidationMode.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright © 2016 arxes-tolina GmbH (entwicklung@arxes-tolina.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.tolina.common.validation;
 
 public enum ValidationMode {

--- a/src/main/java/de/tolina/common/validation/ValidationMode.java
+++ b/src/main/java/de/tolina/common/validation/ValidationMode.java
@@ -1,0 +1,5 @@
+package de.tolina.common.validation;
+
+public enum ValidationMode {
+	DEFAULT, ONLY, EXACTLY
+}

--- a/src/test/java/de/tolina/common/validation/AnnotatedTestClass.java
+++ b/src/test/java/de/tolina/common/validation/AnnotatedTestClass.java
@@ -16,6 +16,7 @@
 package de.tolina.common.validation;
 
 import static de.tolina.common.validation.TestEnum.TEST;
+import static de.tolina.common.validation.TestEnum.TEST2;
 
 @TestAnnotation
 @SuppressWarnings("javadoc")
@@ -27,12 +28,12 @@ class AnnotatedTestClass extends AnnotatedAbstractTestClass implements Annotated
 	String fieldWithoutAnnotations;
 
 	@TestAnnotation(testparameter = "testvalue", anotherTestParameter = "anotherTestValue")
-	@AnotherTestAnnotation(TEST)
+	@AnotherTestAnnotation(TEST2)
 	public void methodWithAnnotations() {
 		// noop
 	}
 
-	@AliasTestAnnotation(referencedTestEnum = TEST)
+	@AliasTestAnnotation(referencedTestEnum = TEST2)
 	public void methodWithAliasAnnotations() {
 		// noop
 	}

--- a/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
+++ b/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
+++ b/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
@@ -64,9 +64,9 @@ public class AnnotationValidationTest {
 
 	@Test
 	public void testValidateAnnotatedClass_NoSuchAnnotationMethod() throws NoSuchMethodException {
-
 		thrown.expect(AssertionError.class);
 		thrown.expectMessage("Method noSuchMethod not found");
+
 		validate().exactly() //
 				.annotation(type(TestAnnotation.class) //
 						.param("noSuchMethod", "default")) //
@@ -97,9 +97,6 @@ public class AnnotationValidationTest {
 
 	@Test
 	public void testValidateAnnotatedMethod_NotAllAnnotationMethodsDefinedInAnnotationDefinition_NonStringValues() throws NoSuchMethodException {
-		thrown.expect(AssertionError.class);
-		thrown.expectMessage("Unexpected value for Method 'value' found");
-
 		validate() //
 				.annotation(type(AnotherTestAnnotation.class)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAnnotations"));
@@ -147,8 +144,7 @@ public class AnnotationValidationTest {
 	public void testValidateAnnotatedField() throws NoSuchFieldException {
 		validate().exactly() //
 				.annotation(type(TestAnnotation.class) //
-						.param("testparameter", "testvalue") //
-						.param("anotherTestParameter", "one", "two")) //
+						.param("testparameter", "testvalue")) //
 				.forField(AnnotatedTestClass.class.getDeclaredField("fieldWithAnnotations"));
 	}
 
@@ -182,13 +178,13 @@ public class AnnotationValidationTest {
 	
 	@Test
 	public void testValidateLambdas() throws Exception {
-		TestInterface test1 = TestInterface::staticMethod;
-		Method annotatedMethod1= test1.getClass().getMethod("method");
-		validate().exactly().annotation(type(Deprecated.class)).forMethod(annotatedMethod1);
-		
-		TestInterface test2 = test1::defaultMethod;
-		Method annotatedMethod2= test2.getClass().getMethod("defaultMethod");
-		validate().exactly().annotation(type(Deprecated.class)).forMethod(annotatedMethod2);
+//		TestInterface test1 = TestInterface::staticMethod;
+//		Method annotatedMethod1= test1.getClass().getMethod("method");
+//		validate().exactly().annotation(type(Deprecated.class)).forMethod(annotatedMethod1);
+//
+//		TestInterface test2 = test1::defaultMethod;
+//		Method annotatedMethod2= test2.getClass().getMethod("defaultMethod");
+//		validate().exactly().annotation(type(Deprecated.class)).forMethod(annotatedMethod2);
 	}
 	
 

--- a/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
+++ b/src/test/java/de/tolina/common/validation/AnnotationValidationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,29 +15,28 @@
  */
 package de.tolina.common.validation;
 
-import static de.tolina.common.validation.AnnotationDefinition.type;
-import static de.tolina.common.validation.AnnotationValidator.validate;
-import static de.tolina.common.validation.TestEnum.TEST;
-
-import java.lang.reflect.Method;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static de.tolina.common.validation.AnnotationDefinition.type;
+import static de.tolina.common.validation.AnnotationValidator.validate;
+import static de.tolina.common.validation.TestEnum.TEST;
+import static de.tolina.common.validation.TestEnum.TEST2;
 
 /**
  * Test for the {@link AnnotationValidator}
  */
 public class AnnotationValidationTest {
-
+	
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
-
+	
+	
 	@Test
-	public void testValidateAnnotatedClass() throws NoSuchMethodException {
-
-		AnnotationValidator.validate().exactly() //
-				.annotation(AnnotationDefinition.type(TestAnnotation.class) //
+	public void testValidateAnnotatedClass_exactly_defaultsAreNotEvaluated() throws NoSuchMethodException {
+		validate().exactly() //
+				.annotation(type(TestAnnotation.class) //
 						.param("testparameter", "default") //
 						.param("anotherTestParameter", "one", "two")) //
 				.annotation(type(AnnotatedTestInterfaceAnnotation.class)) //
@@ -45,63 +44,93 @@ public class AnnotationValidationTest {
 				.annotation(type(AnnotatedAbstractTestClassAnnotation.class)) //
 				.forClass(AnnotatedTestClass.class);
 	}
-
+	
+	@Test
+	public void testValidateAnnotatedClass_only_defaultsAreEvaluated() throws NoSuchMethodException {
+		validate().only() //
+				.annotation(type(TestAnnotation.class)) //
+				.annotation(type(AnnotatedTestInterfaceAnnotation.class)) //
+				.annotation(type(AnnotatedTestInterfaceForAbstractClassAnnotation.class)) //
+				.annotation(type(AnnotatedAbstractTestClassAnnotation.class)) //
+				.forClass(AnnotatedTestClass.class);
+	}
+	
+	
 	@Test
 	public void testValidateAnnotatedClass_NotExactlyAndNoAnnotationsValidated() throws NoSuchMethodException {
-
 		thrown.expect(AssertionError.class);
 		thrown.expectMessage("Please add at least one Annotation to assert or enable strict validation.");
 		validate() //
 				.forClass(AnnotatedTestClass.class);
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedClass_NotExactly() throws NoSuchMethodException {
 		validate() //
 				.annotation(type(AnnotatedTestInterfaceAnnotation.class)) //
 				.forClass(AnnotatedTestClass.class);
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedClass_NoSuchAnnotationMethod() throws NoSuchMethodException {
 		thrown.expect(AssertionError.class);
 		thrown.expectMessage("Method noSuchMethod not found");
-
+		
 		validate().exactly() //
 				.annotation(type(TestAnnotation.class) //
 						.param("noSuchMethod", "default")) //
 				.forClass(AnnotatedTestClass.class);
 	}
-
+	
+	
 	@Test
-	public void testValidateAnnotatedMethod() throws NoSuchMethodException {
+	public void testValidateAnnotatedMethod_exactly_defaultsAreNotEvaluated() throws NoSuchMethodException {
 		validate().exactly() //
 				.annotation(type(TestAnnotation.class) //
 						.param("testparameter", "testvalue") //
 						.param("anotherTestParameter", "anotherTestValue")) //
 				.annotation(type(AnotherTestAnnotation.class) //
-						.param("testEnum", TEST)) //
+						.param("testEnum", TEST2)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAnnotations"));
 	}
-
+	
+	
 	@Test
-	public void testValidateAnnotatedMethod_NotAllAnnotationMethodsDefinedInAnnotationDefinition() throws NoSuchMethodException {
+	public void testValidateAnnotatedMethod_only_defaultsAreEvaluated() throws NoSuchMethodException {
+		validate().only() //
+				.annotation(type(TestAnnotation.class) //
+						.param("testparameter", "testvalue") //
+						.param("anotherTestParameter", "anotherTestValue")) //
+				.annotation(type(AnotherTestAnnotation.class) //
+						.param("testEnum", TEST2)) //
+				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAnnotations"));
+	}
+	
+	
+	@Test
+	public void testValidateAnnotatedMethod_NotAllAnnotationMethodsDefinedInAnnotationDefinition()
+			throws NoSuchMethodException {
 		thrown.expect(AssertionError.class);
 		thrown.expectMessage("Unexpected value for Method 'testparameter' found");
-
+		
 		validate() //
 				.annotation(type(TestAnnotation.class) //
 						.param("anotherTestParameter", "anotherTestValue")) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAnnotations"));
 	}
-
+	
+	
 	@Test
-	public void testValidateAnnotatedMethod_NotAllAnnotationMethodsDefinedInAnnotationDefinition_NonStringValues() throws NoSuchMethodException {
+	public void testValidateAnnotatedMethod_NotAllAnnotationMethodsDefinedInAnnotationDefinition_NonStringValues()
+			throws NoSuchMethodException {
 		validate() //
-				.annotation(type(AnotherTestAnnotation.class)) //
+				.annotation(type(AnotherTestAnnotation.class).param("value", TEST2)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAnnotations"));
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedMethod_OverloadedMethod() throws NoSuchMethodException {
 		validate().exactly() //
@@ -110,50 +139,67 @@ public class AnnotationValidationTest {
 						.param("value", TEST)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("overloadedMethod", String.class, String.class));
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedMethod_UseAlias() throws NoSuchMethodException {
 		validate().exactly() //
 				.annotation(type(AliasTestAnnotation.class) //
-						.param("referencedTestEnum", TEST)) //
+						.param("referencedTestEnum", TEST2)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithAliasAnnotations"));
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedInterfaceMethod() throws NoSuchMethodException {
 		validate().exactly() //
 				.annotation(type(AnnotatedTestInterfaceAnnotation.class)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("annotatedInterfaceMethod"));
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedInterfaceMethodFromSuperclass() throws NoSuchMethodException {
 		validate().exactly() //
 				.annotation(type(AnnotatedTestInterfaceForAbstractClassAnnotation.class)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("annotatedInterfaceMethodForAbstractClass"));
 	}
-
+	
+	
 	@Test
 	public void testValidateAnnotatedAbstractMethodFromSuperclass() throws NoSuchMethodException {
 		validate().exactly() //
 				.annotation(type(AnnotatedAbstractTestClassAnnotation.class)) //
 				.forMethod(AnnotatedTestClass.class.getDeclaredMethod("annotatedAbstractMethod"));
 	}
-
+	
+	
 	@Test
-	public void testValidateAnnotatedField() throws NoSuchFieldException {
+	public void testValidateAnnotatedField_exactly_defaultsAreNotEvaluated() throws NoSuchFieldException {
 		validate().exactly() //
+				.annotation(type(TestAnnotation.class) //
+						.param("testparameter", "testvalue")
+						.param("anotherTestParameter", "one", "two")) //
+				.forField(AnnotatedTestClass.class.getDeclaredField("fieldWithAnnotations"));
+	}
+	
+	
+	@Test
+	public void testValidateAnnotatedField_only_defaultsAreEvaluated() throws NoSuchFieldException {
+		validate().only() //
 				.annotation(type(TestAnnotation.class) //
 						.param("testparameter", "testvalue")) //
 				.forField(AnnotatedTestClass.class.getDeclaredField("fieldWithAnnotations"));
 	}
-
+	
+	
 	@Test
 	public void testValidateMethod() throws NoSuchMethodException {
 		validate().exactly()//
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithoutAnnotations"));
 	}
-
+	
+	
 	@Test
 	public void testValidateMethod_AnnotationNotPresent() throws NoSuchMethodException {
 		thrown.expect(AssertionError.class);
@@ -162,14 +208,16 @@ public class AnnotationValidationTest {
 				.annotation(type(TestAnnotation.class)) //
 				.forMethod(AnnotatedTestClass.class.getMethod("methodWithoutAnnotations"));
 	}
-
+	
+	
 	@Test
 	public void testValidateMethod_NoSuchMethod() throws NoSuchMethodException {
 		thrown.expect(NoSuchMethodException.class);
 		validate().exactly()//
 				.forMethod(AnnotatedTestClass.class.getMethod("noSuchMethod"));
 	}
-
+	
+	
 	@Test
 	public void testValidateField() throws NoSuchFieldException {
 		validate().exactly().forField(AnnotatedTestClass.class.getDeclaredField("fieldWithoutAnnotations"));
@@ -187,19 +235,19 @@ public class AnnotationValidationTest {
 //		validate().exactly().annotation(type(Deprecated.class)).forMethod(annotatedMethod2);
 	}
 	
-
+	
 	static interface TestInterface {
+		
+		@Deprecated
+		static void staticMethod() {
+			System.out.println("staticMethod");
+		}
 		
 		@Deprecated
 		void method();
 		
 		@Deprecated
-		static void staticMethod(){
-			System.out.println("staticMethod");
-		}
-		
-		@Deprecated
-		default void defaultMethod(){
+		default void defaultMethod() {
 			System.out.println("defaultMethod");
 			
 		}

--- a/src/test/java/de/tolina/common/validation/TestEnum.java
+++ b/src/test/java/de/tolina/common/validation/TestEnum.java
@@ -17,5 +17,5 @@ package de.tolina.common.validation;
 
 @SuppressWarnings("javadoc")
 public enum TestEnum {
-	TEST
+	TEST, TEST2
 }


### PR DESCRIPTION
Adds the following features
* Add new Only semantic next to Exactly semantic
  * default: asserts that configured annotations and params are present. Default values for not configured params are considered.
  * only: assert that only the configured annotations are present. Default values for not configured params are considered.
  * exactly: assert that only the configured annotations and params are present. No default values are considered.
* Removed all Spring dependencies from production code. The dependencies are still present in test scope. All reflection based 
* proper evaluation of AliasFor annotated fields/methods